### PR TITLE
chore: update CSS Tricks rates + link

### DIFF
--- a/js/data.json
+++ b/js/data.json
@@ -2,9 +2,10 @@
     {
         "name": "CSS Tricks",
         "type": "publication",
-        "link": "https://css-tricks.com/guest-posting/",
+        "link": "https://css-tricks.com/guest-writing-for-css-tricks/",
         "topics": ["Front-End Development"],
-        "maxRate": 250
+        "minRate": 300,
+        "maxRate": 400
     },
     {
         "name": "No Starch Press",


### PR DESCRIPTION
CSS Tricks was [acquired](https://css-tricks.com/css-tricks-is-joining-digitalocean/) by DigitalOcean so it seems they've inherited the existing rates from DigitalOcean.